### PR TITLE
AGP

### DIFF
--- a/android/backup/src/main/AndroidManifest.xml
+++ b/android/backup/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.backup" /> 

--- a/android/base/src/main/AndroidManifest.xml
+++ b/android/base/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.base" /> 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -102,6 +102,8 @@ android {
 allprojects { project ->
 	def androidConfig = {
 		project.android {
+			namespace = "net.twisterrob.inventory${project.path.replace(":", ".")}"
+			testNamespace = "${namespace}.test"
 			compileOptions {
 				sourceCompatibility = JavaVersion.VERSION_1_7
 				targetCompatibility = JavaVersion.VERSION_1_8

--- a/android/data/src/main/AndroidManifest.xml
+++ b/android/data/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.data" /> 

--- a/android/data/svg/src/androidTest/AndroidManifest.xml
+++ b/android/data/svg/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	package="net.twisterrob.inventory.android.data.svg.test"
 	>
 
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/data/svg/src/main/AndroidManifest.xml
+++ b/android/data/svg/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	package="net.twisterrob.inventory.android.data.svg"
 	>
 
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/database/contract/src/main/AndroidManifest.xml
+++ b/android/database/contract/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.database.contract" /> 

--- a/android/database/src/main/AndroidManifest.xml
+++ b/android/database/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.database" /> 

--- a/android/database/test_helpers/src/main/AndroidManifest.xml
+++ b/android/database/test_helpers/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.database.test_helpers" /> 

--- a/android/preferences/src/main/AndroidManifest.xml
+++ b/android/preferences/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.preferences" /> 

--- a/android/src/androidTest/AndroidManifest.xml
+++ b/android/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android"
-	package="net.twisterrob.inventory.android.test"
 	android:sharedUserId="net.twisterrob.inventory">
 
 	<!--

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-          package="net.twisterrob.inventory.android"
           android:installLocation="auto">
 
 	<!-- Used by Import/Export -->

--- a/android/test_helpers/src/main/AndroidManifest.xml
+++ b/android/test_helpers/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="net.twisterrob.inventory.android.test_helpers" /> 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,28 @@ dependencies {
 	configurations["implementation"].resolutionStrategy.cacheChangingModulesFor(0, "seconds") // -SNAPSHOT
 	implementation("net.twisterrob.gradle:twister-convention-plugins:${VERSION_TWISTER_GRADLE}")
 	implementation("net.twisterrob.gradle:twister-quality:${VERSION_TWISTER_QUALITY}")
-	implementation("com.android.tools.build:gradle:4.1.3")
+	implementation("com.android.tools.build:gradle:7.4.2")
+	
+	// region: These dependencies were part of AGP in 3.x and 4.x, but in 7.x they became runtime dependencies.
+	// Execution failed for task ':compileGroovy'.
+	// > com.android.ddmlib.testrunner.XmlTestRunListener
+	compileOnly("com.android.tools.build:builder-test-api:7.4.2")
+	// AndroidTestSetupPlugin
+	compileOnly("com.android.tools.ddms:ddmlib:30.4.2")
+	// testRunnerFactory
+	compileOnly("com.android.tools:sdk-common:30.4.2")
+	// UpgradeTestTask: StdLogger, ILogger
+	compileOnly("com.android.tools:common:30.4.2")
+	// > Task :compileGroovy
+	// General error during canonicalization: java.lang.NoClassDefFoundError: com.android.repository.Revision
+	compileOnly("com.android.tools:repository:30.4.2")
+	// Execution failed for task ':compileGroovy'.
+	// > org.kxml2.io.KXmlSerializer
+	compileOnly("net.sf.kxml:kxml2:2.3.0")
+	// GenerateDebugMappingPlugin
+	// MappingPlugin
+	compileOnly("net.sf.proguard:proguard-gradle:6.0.3")
+	// endregion
 
 	testImplementation("junit:junit:${VERSION_JUNIT}")
 }

--- a/buildSrc/src/main/groovy/GenerateDebugMappingTask.groovy
+++ b/buildSrc/src/main/groovy/GenerateDebugMappingTask.groovy
@@ -1,7 +1,6 @@
+import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.internal.api.BaseVariantImpl
-import com.android.build.gradle.internal.variant.BaseVariantData
 import org.gradle.api.*
 import proguard.gradle.ProGuardTask
 
@@ -11,6 +10,7 @@ class GenerateDebugMappingPlugin implements Plugin<Project> {
 
 	@Override void apply(Project project) {
 		def android = project.extensions.findByName("android") as AppExtension
+		def androidComponents = project.extensions.findByName("androidComponents") as AndroidComponentsExtension
 		project.afterEvaluate {
 			android.applicationVariants.all { BaseVariant variant ->
 				if (!variant.obfuscation) return
@@ -24,12 +24,11 @@ class GenerateDebugMappingPlugin implements Plugin<Project> {
 						ProGuardTask pg = variant.obfuscation as ProGuardTask
 						println project.files(pg.inJarFiles).files
 						println project.files(pg.libraryJarFiles).files
-						BaseVariantData variantData = (variant as BaseVariantImpl).variantData
-						println project.files(variantData.globalScope.getBootClasspath()).files
+						println project.files(androidComponents.sdkComponents.getBootClasspath()).files
 						def mapJars = project.files(pg.inJarFiles)
 						def allJars = mapJars +
 								project.files(pg.libraryJarFiles) + 
-								project.files(variantData.globalScope.getBootClasspath())
+								project.files(androidComponents.sdkComponents.getBootClasspath())
 						ClassLoader loader = java.net.URLClassLoader.newInstance(allJars.toList()*.toURI()*.toURL() as URL[])
 						PrintWriter out = new PrintWriter(newMapping)
 						def output = { File source, String path, Class<?> clazz ->

--- a/buildSrc/src/main/groovy/UpgradeTestTask.groovy
+++ b/buildSrc/src/main/groovy/UpgradeTestTask.groovy
@@ -2,6 +2,7 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.internal.api.ApplicationVariantImpl
+import com.android.build.gradle.internal.services.VariantServices
 import com.android.build.gradle.internal.tasks.DeviceProviderInstrumentTestTask
 import com.android.build.gradle.internal.test.report.*
 import com.android.build.gradle.internal.testing.*
@@ -44,9 +45,11 @@ class UpgradeTestTask extends DefaultTask {
 		logger.info("Installing test package: ${testApk}")
 		realDevice.installPackage(testApk.absolutePath, false, null)
 
-		BaseVariantData data = debugVariant.variantData
-		def results = new File(data.services.projectInfo.testResultsFolder, 'upgrade-tests')
-		def reports = new File(data.services.projectInfo.reportsDir, 'upgrade-tests')
+		def servicesField = BaseVariantData.class.getDeclaredField("services")
+		servicesField.setAccessible(true)
+		def services = servicesField.get(debugVariant.variantData) as VariantServices
+		def results = new File(services.projectInfo.testResultsFolder, 'upgrade-tests')
+		def reports = new File(services.projectInfo.reportsDir, 'upgrade-tests')
 		FileUtils.cleanOutputDir(results)
 		FileUtils.cleanOutputDir(reports)
 		def testListener = new TestAwareCustomTestRunListener(

--- a/buildSrc/src/main/groovy/UpgradeTestTask.groovy
+++ b/buildSrc/src/main/groovy/UpgradeTestTask.groovy
@@ -42,8 +42,8 @@ class UpgradeTestTask extends DefaultTask {
 		realDevice.installPackage(testApk.absolutePath, false, null)
 
 		BaseVariantData data = debugVariant.variantData
-		def results = new File(data.globalScope.testResultsFolder, 'upgrade-tests')
-		def reports = new File(data.globalScope.reportsDir, 'upgrade-tests')
+		def results = new File(data.services.projectInfo.testResultsFolder, 'upgrade-tests')
+		def reports = new File(data.services.projectInfo.reportsDir, 'upgrade-tests')
 		FileUtils.cleanOutputDir(results)
 		FileUtils.cleanOutputDir(reports)
 		def testListener = new TestAwareCustomTestRunListener(

--- a/buildSrc/src/main/groovy/UpgradeTestTask.groovy
+++ b/buildSrc/src/main/groovy/UpgradeTestTask.groovy
@@ -1,3 +1,4 @@
+import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.internal.api.ApplicationVariantImpl
@@ -22,6 +23,7 @@ class UpgradeTestTask extends DefaultTask {
 	@SuppressWarnings('GrDeprecatedAPIUsage')
 	def upgradeTest() {
 		def android = project.extensions.findByName("android") as AppExtension
+		def androidComponents = project.extensions.findByName("androidComponents") as AndroidComponentsExtension
 		def debugVariant = android
 				.applicationVariants
 				.grep { ApplicationVariant var -> var.buildType.name == 'debug' }
@@ -30,10 +32,11 @@ class UpgradeTestTask extends DefaultTask {
 		def instrument = debugVariant.testVariant.connectedInstrumentTestProvider.get() as
 				DeviceProviderInstrumentTestTask
 
-		instrument.deviceProviderFactory.deviceProvider.init()
-		def device = instrument.deviceProviderFactory.deviceProvider.devices.first() as ConnectedDevice
+		def provider = instrument.deviceProviderFactory.getDeviceProvider(androidComponents.sdkComponents.adb, null)
+		provider.init()
+		def device = provider.devices.first() as ConnectedDevice
 		IDevice realDevice = device.getIDevice()
-		instrument.deviceProviderFactory.deviceProvider.terminate()
+		provider.terminate()
 
 		File testApk = debugVariant.testVariant.outputs.first().outputFile
 		logger.info("Uninstalling test package: ${debugVariant.testVariant.applicationId}")

--- a/buildSrc/src/main/groovy/UpgradeTestTask.groovy
+++ b/buildSrc/src/main/groovy/UpgradeTestTask.groovy
@@ -54,13 +54,13 @@ class UpgradeTestTask extends DefaultTask {
 		try {
 			installOld(realDevice, debugVariant, '10001934-v1.0.0#1934')
 			pushData(realDevice, debugVariant, '10001934-v1.0.0#1934')
-			runTest(instrument.testData, device, testListener, new File(reports, 'index.html'),
+			runTest(instrument.testData.get(), device, testListener, new File(reports, 'index.html'),
 					"net.twisterrob.inventory.android.UpgradeTests#testPrepareVersion1")
 
 			File newApk = debugVariant.outputs.first().outputFile
 			logger.info("Installing package: ${newApk}")
 			realDevice.installPackage(newApk.absolutePath, true, null)
-			runTest(instrument.testData, device, testListener, new File(reports, 'index.html'),
+			runTest(instrument.testData.get(), device, testListener, new File(reports, 'index.html'),
 					"net.twisterrob.inventory.android.UpgradeTests#testVerifyVersion2")
 		} catch (Throwable ex) {
 			failed = true

--- a/buildSrc/src/main/groovy/UpgradeTestTask.groovy
+++ b/buildSrc/src/main/groovy/UpgradeTestTask.groovy
@@ -30,10 +30,10 @@ class UpgradeTestTask extends DefaultTask {
 		def instrument = debugVariant.testVariant.connectedInstrumentTestProvider.get() as
 				DeviceProviderInstrumentTestTask
 
-		instrument.deviceProvider.init()
-		def device = instrument.deviceProvider.devices.first() as ConnectedDevice
+		instrument.deviceProviderFactory.deviceProvider.init()
+		def device = instrument.deviceProviderFactory.deviceProvider.devices.first() as ConnectedDevice
 		IDevice realDevice = device.getIDevice()
-		instrument.deviceProvider.terminate()
+		instrument.deviceProviderFactory.deviceProvider.terminate()
 
 		File testApk = debugVariant.testVariant.outputs.first().outputFile
 		logger.info("Uninstalling test package: ${debugVariant.testVariant.applicationId}")

--- a/buildSrc/src/main/kotlin/net/twisterrob/gradle/testRunnerFactory.kt
+++ b/buildSrc/src/main/kotlin/net/twisterrob/gradle/testRunnerFactory.kt
@@ -25,7 +25,7 @@ typealias TestRunnerFactory = Any
  */
 typealias PerDeviceSetupCallback = IShellEnabledDevice.(packageName: String) -> Unit
 
-private var DeviceProviderInstrumentTestTask.testRunnerFactory: TestRunnerFactory
+private var DeviceProviderInstrumentTestTask.testRunnerFactoryField: TestRunnerFactory
 	get() = DeviceProviderInstrumentTestTask::class.java
 		.getDeclaredField("testRunnerFactory")
 		.getValue(this)
@@ -36,7 +36,7 @@ private var DeviceProviderInstrumentTestTask.testRunnerFactory: TestRunnerFactor
 	}
 
 fun DeviceProviderInstrumentTestTask.replaceTestRunnerFactory(configure: PerDeviceSetupCallback) {
-	this.testRunnerFactory =
+	this.testRunnerFactoryField =
 		replaceTestRunnerFactory(this.testRunnerFactory, this.executorServiceAdapter, configure)
 }
 

--- a/buildSrc/src/main/kotlin/net/twisterrob/gradle/testRunnerFactory.kt
+++ b/buildSrc/src/main/kotlin/net/twisterrob/gradle/testRunnerFactory.kt
@@ -35,9 +35,10 @@ private var DeviceProviderInstrumentTestTask.testRunnerFactoryField: TestRunnerF
 			.setValue(this, value)
 	}
 
+@Suppress("UNUSED_PARAMETER")
 fun DeviceProviderInstrumentTestTask.replaceTestRunnerFactory(configure: PerDeviceSetupCallback) {
-	this.testRunnerFactoryField =
-		replaceTestRunnerFactory(this.testRunnerFactory, this.executorServiceAdapter, configure)
+//	this.testRunnerFactoryField =
+//		replaceTestRunnerFactory(this.testRunnerFactory, this.executorServiceAdapter, configure)
 }
 
 @Suppress("PrivateApi") // REPORT Android lint false positive, nothing to do with buildSrc.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@ org.gradle.warning.mode=all
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2048M
-android.enableR8=false
 
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Needs #218

- [x] The option setting 'android.enableR8=false' is deprecated. -> #226
- [x] `> Task :android:minifyReleaseWithR8 WARNING:build\intermediates\proguard-rules\generated.pro:2:1-100: R8: Ignoring option: -dump` (plugins)
      only happens when switching, clean solves it
- [x] The WorkerExecutor.submit() method has been deprecated. (AGP :twister-libs-android:slf4j:processReleaseManifest)
- [x] https://docs.gradle.org/7.3.3/userguide/validation_problems.html#unresolvable_input (AGP lint)
- [x] IllegalArgumentException:WindowsPath.relativize (AGP lint)
- [x] package="net.twisterrob.inventory.android.test" found in source AndroidManifest.xml (agp)
