### PR TITLE
Release 1.2.0 last minute fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Magic Home Inventory
 
-![Project logo](https://www.twisterrob.net/images/projects/inventory/icon-512.png)
-
----
-
 App Store: https://play.google.com/store/apps/details?id=net.twisterrob.inventory
 
 Website: https://www.twisterrob.net/project/inventory/
 
 See [`docs` folder](docs) for contribution details.
+
+---
+
+![Project logo](android/src/main/art/Hi-res%20Icon.png)

--- a/android/src/androidTest/java/net/twisterrob/inventory/android/activity/ItemEditActivityTest_Edit.java
+++ b/android/src/androidTest/java/net/twisterrob/inventory/android/activity/ItemEditActivityTest_Edit.java
@@ -4,6 +4,9 @@ import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.not;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import net.twisterrob.inventory.android.activity.data.ItemEditActivity;
@@ -59,5 +62,12 @@ public class ItemEditActivityTest_Edit {
 
 		// changes applied
 		db.assertItemHasType(TEST_ITEM, TEST_ITEM_CATEGORY_OTHER);
+	}
+
+	@Category({On.Category.class})
+	@Test public void testShowKeywords() {
+		KeywordsDialogActor keywords = itemEdit.help().showKeywords();
+		keywords.assertKeywords(not(emptyString()));
+		keywords.close();
 	}
 }

--- a/android/src/androidTest/java/net/twisterrob/inventory/android/test/actors/CategoryActivityActor.java
+++ b/android/src/androidTest/java/net/twisterrob/inventory/android/test/actors/CategoryActivityActor.java
@@ -1,0 +1,21 @@
+package net.twisterrob.inventory.android.test.actors;
+
+import net.twisterrob.inventory.android.R;
+import net.twisterrob.inventory.android.activity.data.CategoryActivity;
+
+public class CategoryActivityActor extends ItemContainingViewActivityActor {
+	public CategoryActivityActor() {
+		super(CategoryActivity.class);
+	}
+
+	@Override public void assertShowing(String itemName) {
+		assertActionTitle(itemName);
+	}
+
+	public CategoryActivityActor flatten() {
+		clickActionBar(R.id.action_category_viewAllItems);
+		CategoryActivityActor activity = new CategoryActivityActor();
+		activity.assertIsInFront();
+		return activity;
+	}
+}

--- a/android/src/androidTest/java/net/twisterrob/inventory/android/test/actors/EditActivityActor.java
+++ b/android/src/androidTest/java/net/twisterrob/inventory/android/test/actors/EditActivityActor.java
@@ -99,6 +99,12 @@ public abstract class EditActivityActor extends ActivityActor {
 	public void checkPicture(@ColorInt int backgroundColor) {
 		onView(imageMatcher).perform(scrollTo()).check(matches(withBitmap(hasBackgroundColor(backgroundColor))));
 	}
+	public InfoPopupActor help() {
+		onView(withId(R.id.help)).perform(click());
+		InfoPopupActor popup = new InfoPopupActor();
+		popup.assertDisplayed();
+		return popup;
+	}
 	public SaveResultActor save() {
 		onView(withId(R.id.btn_save)).perform(click());
 		return new SaveResultActor();
@@ -159,6 +165,30 @@ public abstract class EditActivityActor extends ActivityActor {
 		public final void checkToastAlreadyExists() {
 			Matcher<String> matcher = containsStringRes(R.string.generic_error_unique_name);
 			assertToastMessage(withText(matcher));
+		}
+	}
+
+	public static class InfoPopupActor {
+		public void assertDisplayed() {
+			onRoot(isPlatformPopup()).check(matches(isCompletelyDisplayed()));
+		}
+
+		public KeywordsDialogActor showKeywords() {
+			onData(withMenuItemId(R.id.action_category_keywords)).perform(click());
+			KeywordsDialogActor dialog = new KeywordsDialogActor();
+			dialog.assertDisplayed();
+			return dialog;
+		}
+
+		public CategoryActivityActor jumpToCategory() {
+			onData(withMenuItemId(R.id.action_category_goto)).perform(click());
+			CategoryActivityActor activity = new CategoryActivityActor();
+			activity.assertIsInFront();
+			return activity;
+		}
+
+		public void suggestCategories() {
+			onData(withMenuItemId(R.id.action_category_suggest)).perform(click());
 		}
 	}
 }

--- a/android/src/androidTest/java/net/twisterrob/inventory/android/test/actors/KeywordsDialogActor.java
+++ b/android/src/androidTest/java/net/twisterrob/inventory/android/test/actors/KeywordsDialogActor.java
@@ -1,9 +1,12 @@
 package net.twisterrob.inventory.android.test.actors;
 
+import org.hamcrest.Matcher;
+
 import static org.hamcrest.Matchers.anyOf;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.test.espresso.Espresso;
 
@@ -27,6 +30,9 @@ public class KeywordsDialogActor extends AlertDialogActor {
 
 	public void assertKeywords(@StringRes int keywords) {
 		assertDialogMessage(withText(keywords));
+	}
+	public void assertKeywords(@NonNull Matcher<String> matcher) {
+		assertDialogMessage(withText(matcher));
 	}
 
 	public void close() {

--- a/android/src/main/java/net/twisterrob/inventory/android/content/model/CategoryVisuals.java
+++ b/android/src/main/java/net/twisterrob/inventory/android/content/model/CategoryVisuals.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 
 import javax.inject.Inject;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources.NotFoundException;
 import android.text.SpannableStringBuilder;
@@ -95,8 +96,8 @@ public class CategoryVisuals {
 		}
 	}
 
-	public void showKeywords(long categoryID) {
+	public void showKeywords(@NonNull Activity activity, long categoryID) {
 		CharSequence keywords = getKeywords(cache.getCategoryKey(categoryID), true);
-		ChangeTypeDialog.showKeywords(context, cache.getCategoryPath(categoryID), keywords);
+		ChangeTypeDialog.showKeywords(activity, cache.getCategoryPath(categoryID), keywords);
 	}
 }

--- a/android/src/main/java/net/twisterrob/inventory/android/fragment/data/BaseEditFragment.java
+++ b/android/src/main/java/net/twisterrob/inventory/android/fragment/data/BaseEditFragment.java
@@ -236,7 +236,7 @@ public abstract class BaseEditFragment<T, DTO extends ImagedDTO> extends BaseSin
 					Hinter.unhighlight(name.getText());
 				}
 				@Override public void categoryQueried(long categoryID) {
-					visuals.showKeywords(categoryID);
+					visuals.showKeywords(requireActivity(), categoryID);
 				}
 			});
 			hint.setAdapter(hinter.getAdapter());
@@ -281,7 +281,7 @@ public abstract class BaseEditFragment<T, DTO extends ImagedDTO> extends BaseSin
 		// CONSIDER setOnItemLongClickListener is not supported, any way to work around? So user has the same "tooltip" as in ChangeTypeDialog
 		type.setOnLongClickListener(new OnLongClickListener() {
 			@Override public boolean onLongClick(View view) {
-				visuals.showKeywords(getTypeId());
+				visuals.showKeywords(requireActivity(), getTypeId());
 				return true;
 			}
 		});
@@ -330,7 +330,7 @@ public abstract class BaseEditFragment<T, DTO extends ImagedDTO> extends BaseSin
 			updateHint(name.getText(), true);
 			return true;
 		} else if (id == R.id.action_category_keywords) {
-			visuals.showKeywords(getTypeId());
+			visuals.showKeywords(requireActivity(), getTypeId());
 			return true;
 		} else {
 			return super.onContextItemSelected(item);

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,7 +34,8 @@ For the full process see [.github/release.md](https://github.com/TWiStErRob/.git
    adb backup -f Inventory-pre<version>.ab -apk -noobb -noshared -nosystem net.twisterrob.inventory
    # > Now unlock your device and confirm the backup operation...
    # At this point have to press "Back up my data" on the phone really quickly.
-   # If the prompt is shown, it's too late and the backup will not happen regardless what the toast says.
+   # If the CLI prompt is shown after this message,
+   # it's too late and the backup will not happen regardless what the toast says.
    ```
    Note: to restore a backup for testing use
    ```shell

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,7 +22,7 @@ For the full process see [.github/release.md](https://github.com/TWiStErRob/.git
    * `proguard_mapping.txt`
      @ Developer Console
      \> Release
-     \> [App bundle explorer](https://play.google.com/console/u/0/developers/7995455198986011414/app/4974852622245161228/bundle-explorer)
+     \> [App bundle explorer](https://play.google.com/console/u/0/developers/7995455198986011414/app/4974852622245161228/bundle-explorer-selector)
      \> Downloads tab
      \> Assets
      \> ReTrace mapping file

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,7 +34,7 @@ For the full process see [.github/release.md](https://github.com/TWiStErRob/.git
    adb backup -f Inventory-pre<version>.ab -apk -noobb -noshared -nosystem net.twisterrob.inventory
    # > Now unlock your device and confirm the backup operation...
    # At this point have to press "Back up my data" on the phone really quickly.
-   # If the promt is shown, it's too late and the backup will not happen regardless what the toast says.
+   # If the prompt is shown, it's too late and the backup will not happen regardless what the toast says.
    ```
    Note: to restore a backup for testing use
    ```shell

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,6 +31,9 @@ For the full process see [.github/release.md](https://github.com/TWiStErRob/.git
 1. Make a backup of current version on the phone with
    ```shell
    adb backup -f Inventory-pre<version>.ab -apk -noobb -noshared -nosystem net.twisterrob.inventory
+   # > Now unlock your device and confirm the backup operation...
+   # At this point have to press "Back up my data" on the phone really quickly.
+   # If the promt is shown, it's too late and the backup will not happen regardless what the toast says.
    ```
    Note: to restore a backup for testing use
    ```shell

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,7 @@ For the full process see [.github/release.md](https://github.com/TWiStErRob/.git
 
 # Release Process
 
+1. Double-check the version number in `android/build.gradle` is the same as the milestone, if not, PR.
 1. Ensure clean latest working copy.
    ```shell
    git checkout main


### PR DESCRIPTION
Release tasks:
 - [x] Raise bump PR and move todo list there
 - [x] ~[androidx has sealed classes](https://github.com/search?q=repo%3Aandroidx%2Fandroidx+sealed&type=code&p=3), but R8 has a bug, is that going to break?~  
       not an issue, those are Java sealed classes, Kotlin is different.
 - [x] pre launch report
   - [x] crashing keyword dialog
   - [x] weird camera popup (https://github.com/TWiStErRob/net.twisterrob.libraries/pull/78)
 - [x] warnings
![image](https://github.com/TWiStErRob/net.twisterrob.inventory/assets/2906988/2dd1da73-11e4-439f-bbe6-1771597acd6e)
 - [x] manual test
